### PR TITLE
fix: replace deprecated gh release action

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -33,30 +33,20 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
-          prerelease: false
-
       - name: Get Asset name
         run: |
           export PKG=$(ls dist/ | grep tar)
           set -- $PKG
-          echo "name=$1" >> $GITHUB_ENV
+          echo "asset_name=$1" >> $GITHUB_ENV
 
-      - name: Upload Release Asset (sdist) to GitHub
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/${{ env.name }}
-          asset_name: ${{ env.name }}
-          asset_content_type: application/zip
+          name: ${{ github.ref }}
+          tag_name: ${{ github.ref }}
+          files: |
+            dist/${{ env.asset_name }}
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token


### PR DESCRIPTION
# Summary
- replace `actions/create-release` and `actions/upload-release-asset` (both unmaintained) with `softprops/action-gh-release`

This needs to be tested by creating and pushing a tag.